### PR TITLE
[Feature] Packer 생성 & 네트워크 구성 & Jenkins 배포

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,62 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "6.20.0"
+  hashes = [
+    "h1:x9OpnfcX0zYkPdJ38K5vSNe78QZReatBzk/pIlSDU1I=",
+    "zh:05173910d3031e6ba7b985188cff620bbe48cc6bb35ffc30238b9dcd9201c0d4",
+    "zh:0fd36a822e15c473593b5ca826ddfabe248a89833721960781aac65f05a55bc1",
+    "zh:13f478b843ef1fb52780e2771098ae42d6aaceab50d56bc31fdb02ddce6f4621",
+    "zh:16c5a17af7d0fc5329957bc48b5d10b987240076203453a108190132622d40bf",
+    "zh:290342af2da821383b8b5a897920cde2ae01f25768fe5e2df80b80bcc34421cb",
+    "zh:4cfe46a2ed6324467b896aa0dd7fbcf74a94a046d963c8a8fb865e817bcfb955",
+    "zh:78c243a5ec47f6d7066104191480fb13eb85995000cc7c80bc92383baea286a5",
+    "zh:88004fb58967b32061120d1d668e1af1f988da694994cddd11d2d4f7726f5054",
+    "zh:94184d7f00ec5e30d572d56979110e6cf6d5071583713b0e357cca72785e5365",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b219d9c012db507a761c3f3a9147573f25d81d524a076e7c13099f87a50ae386",
+    "zh:beee1b49f414d1d8c03c9c4264725e288d77a676c093e3017de7d10a8ac45582",
+    "zh:e2e76be18ff4c2bf7cfcea9898475ec320b5574c01181581d76d047a2ee7be5c",
+    "zh:fa9afad49b0b2586032afcda2a5813da6e4ba9e56a8a25167b8f659b68e3983d",
+    "zh:fd284feb9f95a20ba848a9027f3c4298d75be6e882df40f075d60955f7bcf170",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.5.3"
+  hashes = [
+    "h1:MCzg+hs1/ZQ32u56VzJMWP9ONRQPAAqAjuHuzbyshvI=",
+    "zh:284d4b5b572eacd456e605e94372f740f6de27b71b4e1fd49b63745d8ecd4927",
+    "zh:40d9dfc9c549e406b5aab73c023aa485633c1b6b730c933d7bcc2fa67fd1ae6e",
+    "zh:6243509bb208656eb9dc17d3c525c89acdd27f08def427a0dce22d5db90a4c8b",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:885d85869f927853b6fe330e235cd03c337ac3b933b0d9ae827ec32fa1fdcdbf",
+    "zh:bab66af51039bdfcccf85b25fe562cbba2f54f6b3812202f4873ade834ec201d",
+    "zh:c505ff1bf9442a889ac7dca3ac05a8ee6f852e0118dd9a61796a2f6ff4837f09",
+    "zh:d36c0b5770841ddb6eaf0499ba3de48e5d4fc99f4829b6ab66b0fab59b1aaf4f",
+    "zh:ddb6a407c7f3ec63efb4dad5f948b54f7f4434ee1a2607a49680d494b1776fe1",
+    "zh:e0dafdd4500bec23d3ff221e3a9b60621c5273e5df867bc59ef6b7e41f5c91f6",
+    "zh:ece8742fd2882a8fc9d6efd20e2590010d43db386b920b2a9c220cfecc18de47",
+    "zh:f4c6b3eb8f39105004cf720e202f04f57e3578441cfb76ca27611139bc116a82",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version = "4.1.0"
+  hashes = [
+    "h1:zEv9tY1KR5vaLSyp2lkrucNJ+Vq3c+sTFK9GyQGLtFs=",
+    "zh:14c35d89307988c835a7f8e26f1b83ce771e5f9b41e407f86a644c0152089ac2",
+    "zh:2fb9fe7a8b5afdbd3e903acb6776ef1be3f2e587fb236a8c60f11a9fa165faa8",
+    "zh:35808142ef850c0c60dd93dc06b95c747720ed2c40c89031781165f0c2baa2fc",
+    "zh:35b5dc95bc75f0b3b9c5ce54d4d7600c1ebc96fbb8dfca174536e8bf103c8cdc",
+    "zh:38aa27c6a6c98f1712aa5cc30011884dc4b128b4073a4a27883374bfa3ec9fac",
+    "zh:51fb247e3a2e88f0047cb97bb9df7c228254a3b3021c5534e4563b4007e6f882",
+    "zh:62b981ce491e38d892ba6364d1d0cdaadcee37cc218590e07b310b1dfa34be2d",
+    "zh:bc8e47efc611924a79f947ce072a9ad698f311d4a60d0b4dfff6758c912b7298",
+    "zh:c149508bd131765d1bc085c75a870abb314ff5a6d7f5ac1035a8892d686b6297",
+    "zh:d38d40783503d278b63858978d40e07ac48123a2925e1a6b47e62179c046f87a",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fb07f708e3316615f6d218cec198504984c0ce7000b9f1eebff7516e384f4b54",
+  ]
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,56 @@
+provider "aws" {
+  region     = var.region
+  access_key = var.aws_access_key
+  secret_key = var.aws_secret_key
+}
+
+module "network" {
+  source               = "./modules/network"
+  vpc_cidr             = var.vpc_cidr
+  azs                  = var.azs
+  public_subnet_cidrs  = var.public_subnet_cidrs
+  private_subnet_cidrs = var.private_subnet_cidrs
+  enable_nat           = var.enable_nat
+  prefix               = var.prefix
+}
+
+module "sg" {
+  source = "./modules/sg"
+  vpc_id = module.network.vpc_id
+}
+
+module "keypair" {
+  source = "./modules/keypair"
+  prefix = var.prefix
+}
+
+module "jenkins" {
+  source        = "./modules/jenkins"
+  ami_id        = var.docker_ami_id
+  instance_type = var.jenkins_instance_type
+  prefix        = var.prefix
+  subnet_id     = module.network.private_subnet_a_id
+  vpc_id        = module.network.vpc_id
+  key_name      = module.keypair.key_name
+  az            = var.azs[0]
+  sg_id         = module.sg.backend_sg_id
+}
+
+module "alb" {
+  source             = "./modules/alb"
+  vpc_id             = module.network.vpc_id
+  alb_sg_id          = module.sg.alb_sg_id
+  subnet_ids         = module.network.public_subnet_ids
+  target_instance_id = module.jenkins.instance_id
+  prefix             = var.prefix
+}
+
+module "bastion" {
+  source        = "./modules/bastion"
+  ami_id        = var.ubuntu_ami_id
+  instance_type = var.bastion_instance_type
+  subnet_id     = module.network.public_subnet_a_id
+  sg_id         = module.sg.bastion_sg_id
+  key_name      = module.keypair.key_name
+  prefix        = var.prefix
+}

--- a/modules/alb/main.tf
+++ b/modules/alb/main.tf
@@ -1,0 +1,47 @@
+resource "aws_lb" "this" {
+  name               = "${var.prefix}-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [var.alb_sg_id]
+  subnets            = var.subnet_ids
+
+  enable_deletion_protection = false
+
+  tags = { Name = "${var.prefix}-alb" }
+}
+
+resource "aws_lb_target_group" "this" {
+  name     = "${var.prefix}-tg"
+  port     = 8080
+  protocol = "HTTP"
+  vpc_id   = var.vpc_id
+
+  health_check {
+    path                = "/"
+    port                = "8080"
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = 5
+    interval            = 30
+    matcher             = "200-399"
+  }
+
+  tags = { Name = "${var.prefix}-tg" }
+}
+
+resource "aws_lb_target_group_attachment" "jenkins" {
+  target_group_arn = aws_lb_target_group.this.arn
+  target_id        = var.target_instance_id
+  port             = 8080
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.this.arn
+  }
+}

--- a/modules/alb/outputs.tf
+++ b/modules/alb/outputs.tf
@@ -1,0 +1,7 @@
+output "tg_arn" {
+  value = aws_lb_target_group.this.arn
+}
+
+output "dns_name" {
+  value = aws_lb.this.dns_name
+}

--- a/modules/alb/variables.tf
+++ b/modules/alb/variables.tf
@@ -1,0 +1,24 @@
+variable "vpc_id" {
+  type        = string
+  description = "VPC ID"
+}
+
+variable "alb_sg_id" {
+  type        = string
+  description = "Security Group ID for ALB"
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "Public Subnet IDs for ALB"
+}
+
+variable "target_instance_id" {
+  type        = string
+  description = "Target EC2 instance to attach"
+}
+
+variable "prefix" {
+  type        = string
+  description = "Name prefix"
+}

--- a/modules/bastion/main.tf
+++ b/modules/bastion/main.tf
@@ -1,0 +1,20 @@
+resource "aws_instance" "this" {
+  ami                         = var.ami_id
+  instance_type               = var.instance_type
+  subnet_id                   = var.subnet_id
+  vpc_security_group_ids      = [var.sg_id]
+  associate_public_ip_address = true
+  key_name                    = var.key_name
+
+  user_data = <<-EOF
+              #!/bin/bash
+              set -eux
+              apt-get update -y
+              apt-get install -y htop vim
+              echo "Bastion host ready" > /etc/motd
+              EOF
+
+  tags = {
+    Name = "${var.prefix}-bastion"
+  }
+}

--- a/modules/bastion/outputs.tf
+++ b/modules/bastion/outputs.tf
@@ -1,0 +1,9 @@
+output "public_ip" {
+  value       = aws_instance.this.public_ip
+  description = "Public IP of the Bastion host"
+}
+
+output "ssh_command" {
+  value       = "ssh -i ${var.prefix}-key.pem ubuntu@${aws_instance.this.public_ip}"
+  description = "SSH command to connect to Bastion"
+}

--- a/modules/bastion/variables.tf
+++ b/modules/bastion/variables.tf
@@ -1,0 +1,30 @@
+variable "ami_id" {
+  type        = string
+  description = "AMI ID for Bastion"
+}
+
+variable "instance_type" {
+  type        = string
+  description = "Instance type for Bastion"
+  default     = "t3.micro"
+}
+
+variable "subnet_id" {
+  type        = string
+  description = "Public subnet ID where Bastion is placed"
+}
+
+variable "sg_id" {
+  type        = string
+  description = "Security Group ID for Bastion"
+}
+
+variable "key_name" {
+  type        = string
+  description = "SSH Key Pair name"
+}
+
+variable "prefix" {
+  type        = string
+  description = "Name prefix for Bastion resources"
+}

--- a/modules/jenkins/main.tf
+++ b/modules/jenkins/main.tf
@@ -1,0 +1,65 @@
+# 기존 EBS 볼륨이 있을 경우
+data "aws_ebs_volume" "existing" {
+  filter {
+    name   = "tag:Name"
+    values = ["${var.prefix}-jenkins-data"]
+  }
+
+  filter {
+    name   = "availability-zone"
+    values = [var.az]
+  }
+
+  most_recent = true
+}
+
+# 기존 EBS 볼륨이 없을 경우에만 생성
+resource "aws_ebs_volume" "data" {
+  count             = data.aws_ebs_volume.existing.id != "" ? 0 : 1
+  availability_zone = var.az
+  size              = 20
+
+  tags = {
+    Name = "${var.prefix}-jenkins-data"
+  }
+
+  lifecycle {
+    prevent_destroy = false
+  }
+}
+
+# Volume ID 결정 (기존 → 신규 순)
+locals {
+  jenkins_volume_id = coalesce(
+    try(data.aws_ebs_volume.existing.id, null),
+    try(aws_ebs_volume.data[0].id, null)
+  )
+}
+
+resource "aws_instance" "this" {
+  ami                         = var.ami_id
+  instance_type               = var.instance_type
+  subnet_id                   = var.subnet_id
+  vpc_security_group_ids      = [var.sg_id]
+  associate_public_ip_address = false
+  key_name                    = var.key_name
+
+  user_data = file("${path.module}/scripts/jenkins-userdata.sh")
+
+  tags = {
+    Name = "${var.prefix}-jenkins"
+  }
+}
+
+resource "aws_volume_attachment" "this" {
+  device_name  = "/dev/sdf"
+  volume_id    = local.jenkins_volume_id
+  instance_id  = aws_instance.this.id
+  force_detach = true
+
+  lifecycle {
+    ignore_changes = [volume_id]
+  }
+
+  depends_on = [aws_instance.this]
+}

--- a/modules/jenkins/outputs.tf
+++ b/modules/jenkins/outputs.tf
@@ -1,0 +1,2 @@
+output "instance_id" { value = aws_instance.this.id }
+output "private_ip" { value = aws_instance.this.private_ip }

--- a/modules/jenkins/scripts/jenkins-userdata.sh
+++ b/modules/jenkins/scripts/jenkins-userdata.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+set -euxo pipefail
+
+# 0) 네트워크가 완전히 준비될 때까지 대기
+apt-get update -y || true  # NAT/라우팅 워밍업 겸 가벼운 트래픽
+systemctl enable docker
+systemctl start docker
+# network-online.target 확실히 대기 (cloud-init보다 늦게 준비되는 경우 대비)
+timeout 120s bash -c 'until systemctl is-active --quiet network-online.target; do sleep 2; done' || true
+# Docker 데몬 준비 대기
+timeout 120s bash -c 'until docker info >/dev/null 2>&1; do sleep 2; done'
+
+MNT="/mnt/jenkins_data"
+
+# 1) 데이터 디스크 탐색(루트 제외) + 준비
+DEVICE=""
+for _ in $(seq 1 120); do
+  CANDIDATE=$(lsblk -ndo NAME,TYPE | awk '$2=="disk"{print $1}' | grep -E '^(nvme|xvd)' | grep -vE 'nvme0n1|xvda' | head -n1 || true)
+  [ -n "$CANDIDATE" ] && DEVICE="/dev/$CANDIDATE"
+  [ -b "$DEVICE" ] && break
+  sleep 2
+done
+
+if [ -z "${DEVICE:-}" ] || [ ! -b "$DEVICE" ]; then
+  echo "EBS device not found; skipping mount to let instance come up"; exit 0
+fi
+
+if ! blkid "$DEVICE" >/dev/null 2>&1; then
+  mkfs -t ext4 "$DEVICE"
+fi
+
+mkdir -p "$MNT"
+if ! mount | grep -q "$MNT"; then
+  mount "$DEVICE" "$MNT"
+  echo "$DEVICE $MNT ext4 defaults,nofail 0 2" >> /etc/fstab
+fi
+chown -R ubuntu:ubuntu "$MNT"
+
+# 2) docker pull 재시도 (exponential backoff, 최대 ~2분)
+IMG="jenkins/jenkins:lts-jdk17"
+for i in 1 2 3 4 5 6; do
+  if docker pull "$IMG"; then break; fi
+  sleep $((i*5))
+done
+
+# 3) 컨테이너 기동 (존재하면 재사용)
+if ! docker ps -a --format '{{.Names}}' | grep -q '^jenkins$'; then
+  docker run -d --name jenkins \
+    -p 8080:8080 -p 50000:50000 \
+    -v "$MNT":/var/jenkins_home \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    "$IMG"
+fi
+
+# 4) 재부팅 자동기동용 systemd 유닛 (네트워크 준비 후 실행)
+cat >/etc/systemd/system/jenkins-container.service <<'SERVICE'
+[Unit]
+Description=Jenkins Docker Container
+Wants=network-online.target docker.service
+After=network-online.target docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStartPre=/usr/bin/bash -c 'for i in 1 2 3 4 5 6; do docker pull jenkins/jenkins:lts-jdk17 && break || sleep $((i*5)); done'
+ExecStart=/usr/bin/docker start jenkins || /usr/bin/docker run -d --name jenkins -p 8080:8080 -p 50000:50000 -v /mnt/jenkins_data:/var/jenkins_home -v /var/run/docker.sock:/var/run/docker.sock jenkins/jenkins:lts-jdk17
+ExecStop=/usr/bin/docker stop -t 5 jenkins
+
+[Install]
+WantedBy=multi-user.target
+SERVICE
+
+systemctl daemon-reload
+systemctl enable jenkins-container.service

--- a/modules/jenkins/variables.tf
+++ b/modules/jenkins/variables.tf
@@ -1,0 +1,8 @@
+variable "ami_id" {}
+variable "instance_type" {}
+variable "subnet_id" {}
+variable "vpc_id" {}
+variable "key_name" {}
+variable "sg_id" {}
+variable "az" {}
+variable "prefix" {}

--- a/modules/keypair/main.tf
+++ b/modules/keypair/main.tf
@@ -1,0 +1,15 @@
+resource "tls_private_key" "this" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "aws_key_pair" "this" {
+  key_name   = "${var.prefix}-key"
+  public_key = tls_private_key.this.public_key_openssh
+}
+
+resource "local_file" "pem" {
+  content         = tls_private_key.this.private_key_pem
+  filename        = "${path.root}/${var.prefix}-key.pem"
+  file_permission = "0600"
+}

--- a/modules/keypair/outputs.tf
+++ b/modules/keypair/outputs.tf
@@ -1,0 +1,3 @@
+output "key_name" {
+  value = aws_key_pair.this.key_name
+}

--- a/modules/keypair/variables.tf
+++ b/modules/keypair/variables.tf
@@ -1,0 +1,1 @@
+variable "prefix" {}

--- a/modules/network/elastic_ip.tf
+++ b/modules/network/elastic_ip.tf
@@ -1,0 +1,9 @@
+# NAT 전용 EIP (enable_nat=false면 생성 안 함)
+resource "aws_eip" "nat" {
+  count  = var.enable_nat ? 1 : 0
+  domain = "vpc"
+
+  tags = {
+    Name = "${var.prefix}-nat-eip"
+  }
+}

--- a/modules/network/internet_gateway.tf
+++ b/modules/network/internet_gateway.tf
@@ -1,0 +1,7 @@
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+
+  tags = {
+    Name = "${var.prefix}-igw"
+  }
+}

--- a/modules/network/nat_gateway.tf
+++ b/modules/network/nat_gateway.tf
@@ -1,0 +1,11 @@
+resource "aws_nat_gateway" "this" {
+  count         = var.enable_nat ? 1 : 0
+  allocation_id = aws_eip.nat[0].id
+  subnet_id     = aws_subnet.public_a.id
+
+  tags = {
+    Name = "${var.prefix}-nat"
+  }
+
+  depends_on = [aws_internet_gateway.this]
+}

--- a/modules/network/outputs.tf
+++ b/modules/network/outputs.tf
@@ -1,0 +1,8 @@
+output "vpc_id" { value = aws_vpc.this.id }
+output "public_subnet_ids" { value = [aws_subnet.public_a.id, aws_subnet.public_b.id] }
+output "private_subnet_ids" { value = [aws_subnet.private_a.id, aws_subnet.private_b.id] }
+output "public_subnet_a_id" { value = aws_subnet.public_a.id }
+output "private_subnet_a_id" { value = aws_subnet.private_a.id }
+output "nat_gateway_id" { value = var.enable_nat ? aws_nat_gateway.this[0].id : null }
+output "public_route_table_id" { value = aws_route_table.public.id }
+output "private_route_table_id" { value = aws_route_table.private.id }

--- a/modules/network/route_tables.tf
+++ b/modules/network/route_tables.tf
@@ -1,0 +1,48 @@
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+
+  tags = {
+    Name = "${var.prefix}-public-rt"
+  }
+}
+
+resource "aws_route" "public_default" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.this.id
+}
+
+resource "aws_route_table_association" "public_a" {
+  subnet_id      = aws_subnet.public_a.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "public_b" {
+  subnet_id      = aws_subnet.public_b.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.this.id
+
+  tags = {
+    Name = "${var.prefix}-private-rt"
+  }
+}
+
+resource "aws_route" "private_default_via_nat" {
+  count                  = var.enable_nat ? 1 : 0
+  route_table_id         = aws_route_table.private.id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.this[0].id
+}
+
+resource "aws_route_table_association" "private_a" {
+  subnet_id      = aws_subnet.private_a.id
+  route_table_id = aws_route_table.private.id
+}
+
+resource "aws_route_table_association" "private_b" {
+  subnet_id      = aws_subnet.private_b.id
+  route_table_id = aws_route_table.private.id
+}

--- a/modules/network/subnets.tf
+++ b/modules/network/subnets.tf
@@ -1,0 +1,47 @@
+# Public subnets
+resource "aws_subnet" "public_a" {
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = var.public_subnet_cidrs[0]
+  availability_zone       = var.azs[0]
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "${var.prefix}-public-a"
+    Tier = "public"
+  }
+}
+
+resource "aws_subnet" "public_b" {
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = var.public_subnet_cidrs[1]
+  availability_zone       = var.azs[1]
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "${var.prefix}-public-b"
+    Tier = "public"
+  }
+}
+
+# Private subnets
+resource "aws_subnet" "private_a" {
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = var.private_subnet_cidrs[0]
+  availability_zone = var.azs[0]
+
+  tags = {
+    Name = "${var.prefix}-private-a"
+    Tier = "private"
+  }
+}
+
+resource "aws_subnet" "private_b" {
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = var.private_subnet_cidrs[1]
+  availability_zone = var.azs[1]
+
+  tags = {
+    Name = "${var.prefix}-private-b"
+    Tier = "private"
+  }
+}

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -1,0 +1,31 @@
+variable "vpc_cidr" {
+  type        = string
+  description = "CIDR block for the VPC"
+}
+
+variable "azs" {
+  type        = list(string)
+  description = "Availability Zones"
+}
+
+variable "public_subnet_cidrs" {
+  type        = list(string)
+  description = "Public subnet CIDRs"
+}
+
+variable "private_subnet_cidrs" {
+  type        = list(string)
+  description = "Private subnet CIDRs"
+}
+
+variable "enable_nat" {
+  type        = bool
+  description = "Enable NAT Gateway"
+  default     = true
+}
+
+variable "prefix" {
+  type        = string
+  description = "Prefix for resource names"
+  default     = "come2us"
+}

--- a/modules/network/vpc.tf
+++ b/modules/network/vpc.tf
@@ -1,0 +1,9 @@
+resource "aws_vpc" "this" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "${var.prefix}-vpc"
+  }
+}

--- a/modules/sg/main.tf
+++ b/modules/sg/main.tf
@@ -1,0 +1,105 @@
+resource "aws_security_group" "bastion_sg" {
+  name   = "bastion-sg"
+  vpc_id = var.vpc_id
+
+  ingress {
+    description = "Allow SSH from anywhere (restrict in production)"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "come2us-bastion-sg"
+  }
+}
+
+resource "aws_security_group" "backend_sg" {
+  name   = "backend-sg"
+  vpc_id = var.vpc_id
+
+  ingress {
+    description     = "Allow SSH from Bastion"
+    from_port       = 22
+    to_port         = 22
+    protocol        = "tcp"
+    security_groups = [aws_security_group.bastion_sg.id]
+  }
+
+  ingress {
+    description     = "Allow HTTP traffic from ALB"
+    from_port       = 8080
+    to_port         = 8080
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb_sg.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "come2us-backend-sg"
+  }
+}
+
+resource "aws_security_group" "rds_sg" {
+  name   = "rds-sg"
+  vpc_id = var.vpc_id
+
+  ingress {
+    description     = "Allow PostgreSQL access from Backend"
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.backend_sg.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "come2us-rds-sg"
+  }
+}
+
+resource "aws_security_group" "alb_sg" {
+  name        = "alb-sg"
+  description = "Security group for Application Load Balancer"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description = "Allow inbound HTTP from anywhere"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "Allow ALB to reach backend on 8080"
+    from_port   = 8080
+    to_port     = 8080
+    protocol    = "tcp"
+    cidr_blocks = ["10.0.0.0/16"]
+  }
+
+  tags = {
+    Name = "come2us-alb-sg"
+  }
+}

--- a/modules/sg/outputs.tf
+++ b/modules/sg/outputs.tf
@@ -1,0 +1,4 @@
+output "bastion_sg_id" { value = aws_security_group.bastion_sg.id }
+output "backend_sg_id" { value = aws_security_group.backend_sg.id }
+output "alb_sg_id" { value = aws_security_group.alb_sg.id }
+output "rds_sg_id" { value = aws_security_group.rds_sg.id }

--- a/modules/sg/variables.tf
+++ b/modules/sg/variables.tf
@@ -1,0 +1,1 @@
+variable "vpc_id" {}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,10 @@
+output "alb_dns" { value = module.alb.dns_name }
+output "jenkins_private_ip" { value = module.jenkins.private_ip }
+
+output "bastion_public_ip" {
+  value = module.bastion.public_ip
+}
+
+output "bastion_ssh" {
+  value = module.bastion.ssh_command
+}

--- a/packer/docker-ubuntu.pkr.hcl
+++ b/packer/docker-ubuntu.pkr.hcl
@@ -1,0 +1,63 @@
+packer {
+  required_plugins {
+    amazon = {
+      source  = "github.com/hashicorp/amazon"
+      version = ">= 1.2.0"
+    }
+  }
+}
+
+variable "region" {
+  default = "ap-northeast-2"
+}
+
+variable "ami_name" {
+  type    = string
+  default = "docker-ubuntu"
+}
+
+source "amazon-ebs" "docker_ubuntu" {
+  profile                     = "come2us"
+  region                      = var.region
+  instance_type               = "t3.small"
+  ssh_username                = "ubuntu"
+  ami_name                    = "${var.ami_name}"
+  ami_description             = "Ubuntu 22.04 LTS with Docker preinstalled"
+  associate_public_ip_address = true
+
+  source_ami_filter {
+    filters = {
+      name                = "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+    }
+    owners      = ["099720109477"] # Canonical
+    most_recent = true
+  }
+
+  tags = {
+    Name = "docker-ubuntu-base"
+  }
+}
+
+build {
+  name    = "docker-ubuntu"
+  sources = ["source.amazon-ebs.docker_ubuntu"]
+
+  provisioner "shell" {
+    inline = [
+      "sudo rm -rf /var/lib/apt/lists/*",
+      "sudo mkdir -p /var/lib/apt/lists/partial",
+      "sudo apt-get clean",
+      "sudo apt-get update -y -o Acquire::CompressionTypes::Order::=gz",
+      "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https ca-certificates curl software-properties-common",
+      "curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -",
+      "sudo add-apt-repository \"deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable\"",
+      "sudo apt-get update -y",
+      "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker-ce docker-ce-cli containerd.io",
+      "sudo systemctl enable docker",
+      "sudo usermod -aG docker ubuntu",
+      "sudo systemctl start docker"
+    ]
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,92 @@
+# provider
+variable "region" {
+  default = "ap-northeast-2"
+}
+
+variable "aws_access_key" {
+  type        = string
+  description = "AWS Access Key"
+}
+
+variable "aws_secret_key" {
+  type        = string
+  description = "AWS Secret Key"
+}
+
+# common
+variable "prefix" {
+  default     = "come2us"
+  type        = string
+  description = "Jenkins Instance Type"
+}
+
+# jenkins
+variable "docker_ami_id" {
+  type        = string
+  description = "AWS Machine Images"
+}
+
+variable "jenkins_instance_type" {
+  type        = string
+  description = "Jenkins Instance Type"
+}
+
+# network
+variable "vpc_cidr" {
+  type    = string
+  default = "10.0.0.0/16"
+}
+
+variable "azs" {
+  type    = list(string)
+  default = ["ap-northeast-2a", "ap-northeast-2b"]
+}
+
+variable "public_subnet_cidrs" {
+  type        = list(string)
+  description = "Public subnet CIDRs"
+}
+
+variable "private_subnet_cidrs" {
+  type        = list(string)
+  description = "Private subnet CIDRs"
+}
+
+variable "enable_nat" {
+  type        = bool
+  description = "Enable NAT Gateway in public_a"
+  default     = true
+}
+
+# bastion
+variable "bastion_instance_type" {
+  default = "t3.micro"
+}
+
+variable "ubuntu_ami_id" {
+  type        = string
+  description = "AMI for Bastion host"
+  default     = "ami-0c9c942bd7bf113a2" # Ubuntu 22.04
+}
+
+# RDS
+variable "rds_db_name" {
+  type = string
+}
+
+variable "rds_instance_class" {
+  default = "db.t3.micro"
+}
+
+variable "rds_allocated_storage" {
+  default = 20
+}
+
+variable "rds_username" {
+  type = string
+}
+
+variable "rds_password" {
+  type      = string
+  sensitive = true
+}


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #3

## 📌 **작업 내용 및 특이사항**
Packer를 이용한 Docker 베이스 AMI 생성 및 기초 네트워크 인프라(VPC, Subnet, NAT, SG 등) 구성, Jenkins 서버 자동 배포(Private Subnet + EBS 연동)

### Packer (Docker Base AMI)
- 베이스 이미지: ubuntu/jammy-22.04
- 빌드 위치: ap-northeast-2
- 설치 항목
  - Docker CE
  - Cloud-init 최신 버전
- 산출물:
  - AMI: come2us-docker-base
- 사용 목적: Jenkins, Backend 서비스 공통 베이스

### 네트워크 구성
항목 | 세부 내용
-- | --
Region | ap-northeast-2 (Seoul)
VPC | CIDR 10.0.0.0/16
Availability Zones | ap-northeast-2a, ap-northeast-2c
Subnets | Public(2), Private(2)
Internet Gateway (IGW) | 외부 통신용 (Public Subnet 연결)
NAT Gateway | public-a에 위치, Private Subnet 인터넷 접근 허용
EIP (Elastic IP) | NAT Gateway용 할당
Route Tables | Public/Private 분리 관리
Tag Prefix | come2us-*

### 보안 그룹
SG 이름 | 목적 | 주요 Ingress | 주요 Egress
-- | -- | -- | --
bastion-sg | SSH 진입점 | 22/tcp (0.0.0.0/0 → 추후 사내 IP로 제한 예정) | all
backend-sg | Jenkins 및 내부 서비스용 | 22/tcp from Bastion8080/tcp from ALB | all
rds-sg | DB 접근 보호 | 5432/tcp from backend-sg | all
alb-sg | 외부 트래픽 진입점 | 80/tcp from 0.0.0.0/0 | 8080/tcp to backend-sg

### Jenkins 구성
- 서브넷: private-a
- AMI: Packer로 생성한 Docker 기반 AMI
- EBS: come2us-jenkins-data (20GB, prevent_destroy = true)
  - Jenkins 데이터 지속성 보장 (destroy 시에도 유지)
- User Data Script
  - 네트워크/도커 초기화 대기 (network-online.target)
  - EBS 자동 탐색 및 마운트
  - Jenkins 컨테이너 자동 실행 및 systemd 등록
  - Docker Pull 재시도 로직 포함 (NAT 초기화 대비)
- 보안 그룹: backend-sg
- ALB Target Group: Jenkins 인스턴스 연결

### Bastion Host
- 서브넷: public-a
- AMI: Ubuntu 22.04 LTS
- 인스턴스 타입: t3.micro
- 접속 방식: SSH (come2us-key.pem)
- 보안 그룹: bastion-sg
  (향후 사내 IP 화이트리스트 적용 예정)

📚 **참고사항**
