### PR TITLE
[Fix] Jenkins EBS 볼륨 조회 및 생성 로직 개선

### DIFF
--- a/modules/jenkins/main.tf
+++ b/modules/jenkins/main.tf
@@ -1,5 +1,5 @@
 # 기존 EBS 볼륨이 있을 경우
-data "aws_ebs_volume" "existing" {
+data "aws_ebs_volumes" "existing" {
   filter {
     name   = "tag:Name"
     values = ["${var.prefix}-jenkins-data"]
@@ -9,13 +9,15 @@ data "aws_ebs_volume" "existing" {
     name   = "availability-zone"
     values = [var.az]
   }
+}
 
-  most_recent = true
+locals {
+  existing_volume_ids = try(data.aws_ebs_volumes.existing.ids, [])
 }
 
 # 기존 EBS 볼륨이 없을 경우에만 생성
 resource "aws_ebs_volume" "data" {
-  count             = data.aws_ebs_volume.existing.id != "" ? 0 : 1
+  count             = length(local.existing_volume_ids) > 0 ? 0 : 1
   availability_zone = var.az
   size              = 20
 
@@ -24,14 +26,14 @@ resource "aws_ebs_volume" "data" {
   }
 
   lifecycle {
-    prevent_destroy = false
+    prevent_destroy = true
   }
 }
 
 # Volume ID 결정 (기존 → 신규 순)
 locals {
   jenkins_volume_id = coalesce(
-    try(data.aws_ebs_volume.existing.id, null),
+    try(local.existing_volume_ids[0], null),
     try(aws_ebs_volume.data[0].id, null)
   )
 }


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #7

📌 **작업 내용 및 특이사항**
- 기존 `aws_ebs_volume` 단일 데이터소스 사용 시, 조회 결과가 없을 경우 `"Your query returned no results"` 에러 발생하던 문제를 수정
- `aws_ebs_volumes` (복수형) 데이터소스로 변경하여, 결과가 없을 경우 빈 리스트([])를 반환하도록 개선 → 첫 Apply 시 오류 방지
- 기존 EBS 자동 재사용 로직 안정화:
  - 동일 `tag:Name = <prefix>-jenkins-data` 조건으로 조회
  - 존재 시 재활용, 없을 경우 자동 생성
- Volume ID 결정 로직을 `coalesce()` 기반으로 단일화
- Jenkins EC2 인스턴스 생성 및 볼륨 attach 과정 불변성 유지 (`ignore_changes`)



📚 **참고사항**
- 향후 백업 자동화를 위해 `aws_backup_plan` 또는 `ebs snapshot lifecycle` 정책 적용 예정
- Jenkins 인스턴스 교체 시에도 데이터 손실 없이 복구 가능