### PR TITLE
[Fix] Terraform provider 버전 명시 (~> 6.0)로 schema timeout 문제 해결

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,10 @@
 terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
   backend "s3" {}
 }
 


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #12 

### 📌 **작업 내용 및 특이사항**
- `.terraform/`, `.terraform.lock.hcl` 모두 제거
- `main.tf` 내 `required_providers` 블록 추가
  - AWS provider 버전을 `~> 6.0`으로 명시
  - 동일 major 버전 내에서 최신 안정 버전 자동 설치 가능
```hcl
terraform {
  required_providers {
    aws = {
      source  = "hashicorp/aws"
      version = "~> 6.0"
    }
  }
}
```
- 이후 backend 재초기화:
  ```bash
  terraform init -backend-config=env/backend.hcl -reconfigure
  ```

### ✅ 문제 원인
- backend 연결 과정에서 provider schema mismatch로 인해 plugin timeout 발생
- `.terraform` 캐시 및 `.terraform.lock.hcl` 파일이 남아있던 상태에서 provider 버전이 명시되지 않아 충돌 발생

### ✅ 해결 결과
- backend 초기화(`terraform init -reconfigure`) 정상 완료
- provider schema handshake 오류 해결
- `terraform plan` 정상 수행 확인
