### PR TITLE
[Feature] Terraform 기반 RDS 구성 추가

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -79,6 +79,22 @@ module "bastion" {
   prefix        = var.prefix
 }
 
+# RDS
+module "rds" {
+  source        = "./modules/rds"
+  prefix        = "${var.prefix}-db"
+  subnet_ids    = module.network.db_subnet_ids
+  vpc_id        = module.network.vpc_id
+  sg_id = module.sg.rds_sg_id
+  instance_class = var.rds_instance_class
+  allocated_storage = var.rds_allocated_storage
+  engine_version = var.rds_engine_version
+  db_name       = var.rds_db_name
+  username      = var.rds_username
+  password      = var.rds_password
+  port = var.rds_port
+}
+
 resource "aws_ecs_cluster" "come2us" {
   name = "${var.prefix}-cluster"
 }

--- a/main.tf
+++ b/main.tf
@@ -24,6 +24,7 @@ module "network" {
   azs                  = var.azs
   public_subnet_cidrs  = var.public_subnet_cidrs
   private_subnet_cidrs = var.private_subnet_cidrs
+  db_subnet_cidrs      = var.db_subnet_cidrs
   enable_nat           = var.enable_nat
   prefix               = var.prefix
 }

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "~> 6.0"
     }
   }
@@ -81,18 +81,18 @@ module "bastion" {
 
 # RDS
 module "rds" {
-  source        = "./modules/rds"
-  prefix        = "${var.prefix}-db"
-  subnet_ids    = module.network.db_subnet_ids
-  vpc_id        = module.network.vpc_id
-  sg_id = module.sg.rds_sg_id
-  instance_class = var.rds_instance_class
+  source            = "./modules/rds"
+  prefix            = "${var.prefix}-db"
+  subnet_ids        = module.network.db_subnet_ids
+  vpc_id            = module.network.vpc_id
+  sg_id             = module.sg.rds_sg_id
+  instance_class    = var.rds_instance_class
   allocated_storage = var.rds_allocated_storage
-  engine_version = var.rds_engine_version
-  db_name       = var.rds_db_name
-  username      = var.rds_username
-  password      = var.rds_password
-  port = var.rds_port
+  engine_version    = var.rds_engine_version
+  db_name           = var.rds_db_name
+  username          = var.rds_username
+  password          = var.rds_password
+  port              = var.rds_port
 }
 
 resource "aws_ecs_cluster" "come2us" {

--- a/modules/network/outputs.tf
+++ b/modules/network/outputs.tf
@@ -6,3 +6,4 @@ output "private_subnet_a_id" { value = aws_subnet.private_a.id }
 output "nat_gateway_id" { value = var.enable_nat ? aws_nat_gateway.this[0].id : null }
 output "public_route_table_id" { value = aws_route_table.public.id }
 output "private_route_table_id" { value = aws_route_table.private.id }
+output "db_subnet_ids" { value = [aws_subnet.db_private_a.id, aws_subnet.db_private_b.id] }

--- a/modules/network/route_tables.tf
+++ b/modules/network/route_tables.tf
@@ -56,11 +56,11 @@ resource "aws_route_table" "db_private" {
 }
 
 resource "aws_route_table_association" "db_private_a" {
-  subnet_id = aws_subnet.db_private_a.id
+  subnet_id      = aws_subnet.db_private_a.id
   route_table_id = aws_route_table.db_private.id
 }
 
 resource "aws_route_table_association" "db_private_b" {
-  subnet_id = aws_subnet.db_private_b.id
+  subnet_id      = aws_subnet.db_private_b.id
   route_table_id = aws_route_table.db_private.id
 }

--- a/modules/network/route_tables.tf
+++ b/modules/network/route_tables.tf
@@ -46,3 +46,21 @@ resource "aws_route_table_association" "private_b" {
   subnet_id      = aws_subnet.private_b.id
   route_table_id = aws_route_table.private.id
 }
+
+resource "aws_route_table" "db_private" {
+  vpc_id = aws_vpc.this.id
+
+  tags = {
+    Name = "${var.prefix}-db-private-rt"
+  }
+}
+
+resource "aws_route_table_association" "db_private_a" {
+  subnet_id = aws_subnet.db_private_a.id
+  route_table_id = aws_route_table.db_private.id
+}
+
+resource "aws_route_table_association" "db_private_b" {
+  subnet_id = aws_subnet.db_private_b.id
+  route_table_id = aws_route_table.db_private.id
+}

--- a/modules/network/subnets.tf
+++ b/modules/network/subnets.tf
@@ -45,3 +45,25 @@ resource "aws_subnet" "private_b" {
     Tier = "private"
   }
 }
+
+resource "aws_subnet" "db_private_a" {
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = var.db_subnet_cidrs[0]
+  availability_zone = var.azs[0]
+
+  tags = {
+    Name = "${var.prefix}-db-private-a"
+    Tier = "db"
+  }
+}
+
+resource "aws_subnet" "db_private_b" {
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = var.db_subnet_cidrs[1]
+  availability_zone = var.azs[1]
+
+  tags = {
+    Name = "${var.prefix}-db-private-b"
+    Tier = "db"
+  }
+}

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -31,6 +31,6 @@ variable "prefix" {
 }
 
 variable "db_subnet_cidrs" {
-  type = list(string)
+  type        = list(string)
   description = "Private subnet CIDRs for RDS"
 }

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -29,3 +29,8 @@ variable "prefix" {
   description = "Prefix for resource names"
   default     = "come2us"
 }
+
+variable "db_subnet_cidrs" {
+  type = list(string)
+  description = "Private subnet CIDRs for RDS"
+}

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -1,5 +1,5 @@
 resource "aws_db_subnet_group" "come2us_db_subnet" {
-  name = "${prefix}-subnet-group"
+  name = "${var.prefix}-subnet-group"
   subnet_ids = var.subnet_ids
 
   tags = {
@@ -21,11 +21,11 @@ resource "aws_db_instance" "come2us_rds" {
 
   skip_final_snapshot = true
   deletion_protection = false
-  multi_az = false
+  multi_az = true
   publicly_accessible = false
   storage_encrypted = false
   auto_minor_version_upgrade = true
-  backup_retention_period = 1
+  backup_retention_period = 7
 
   vpc_security_group_ids = [ var.sg_id ]
   db_subnet_group_name = aws_db_subnet_group.come2us_db_subnet.name
@@ -34,6 +34,7 @@ resource "aws_db_instance" "come2us_rds" {
     Name = "${var.prefix}-primary"
     Environment = "dev"
     ManagedBy = "Terraform"
+    Role = "primary"
   }
 }
 
@@ -51,5 +52,6 @@ resource "aws_db_instance" "come2us_rds_replica" {
     Name = "${var.prefix}-replica"
     Environment = "dev"
     ManagedBy = "Terraform"
+    Role = "read-replica"
   }
 }

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -1,0 +1,55 @@
+resource "aws_db_subnet_group" "come2us_db_subnet" {
+  name = "${prefix}-subnet-group"
+  subnet_ids = var.subnet_ids
+
+  tags = {
+    Name = "${var.prefix}-subnet-group"
+  }
+}
+
+resource "aws_db_instance" "come2us_rds" {
+  identifier = "${var.prefix}-primary"
+  engine = "postgres"
+  engine_version = var.engine_version
+  instance_class = var.instance_class
+  allocated_storage = var.allocated_storage
+  storage_type = "gp2"
+  username = var.username
+  password = var.password
+  db_name = var.db_name
+  port = var.port
+
+  skip_final_snapshot = true
+  deletion_protection = false
+  multi_az = false
+  publicly_accessible = false
+  storage_encrypted = false
+  auto_minor_version_upgrade = true
+  backup_retention_period = 1
+
+  vpc_security_group_ids = [ var.sg_id ]
+  db_subnet_group_name = aws_db_subnet_group.come2us_db_subnet.name
+
+  tags = {
+    Name = "${var.prefix}-primary"
+    Environment = "dev"
+    ManagedBy = "Terraform"
+  }
+}
+
+resource "aws_db_instance" "come2us_rds_replica" {
+  identifier = "${var.prefix}-replica"
+  replicate_source_db = aws_db_instance.come2us_rds.arn
+  instance_class = var.instance_class
+  publicly_accessible = false
+  auto_minor_version_upgrade = true
+  skip_final_snapshot = true
+
+  depends_on = [ aws_db_instance.come2us_rds ]
+
+  tags = {
+    Name = "${var.prefix}-replica"
+    Environment = "dev"
+    ManagedBy = "Terraform"
+  }
+}

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -1,5 +1,5 @@
 resource "aws_db_subnet_group" "come2us_db_subnet" {
-  name = "${var.prefix}-subnet-group"
+  name       = "${var.prefix}-subnet-group"
   subnet_ids = var.subnet_ids
 
   tags = {
@@ -8,50 +8,50 @@ resource "aws_db_subnet_group" "come2us_db_subnet" {
 }
 
 resource "aws_db_instance" "come2us_rds" {
-  identifier = "${var.prefix}-primary"
-  engine = "postgres"
-  engine_version = var.engine_version
-  instance_class = var.instance_class
+  identifier        = "${var.prefix}-primary"
+  engine            = "postgres"
+  engine_version    = var.engine_version
+  instance_class    = var.instance_class
   allocated_storage = var.allocated_storage
-  storage_type = "gp2"
-  username = var.username
-  password = var.password
-  db_name = var.db_name
-  port = var.port
+  storage_type      = "gp2"
+  username          = var.username
+  password          = var.password
+  db_name           = var.db_name
+  port              = var.port
 
-  skip_final_snapshot = true
-  deletion_protection = false
-  multi_az = true
-  publicly_accessible = false
-  storage_encrypted = false
+  skip_final_snapshot        = true
+  deletion_protection        = false
+  multi_az                   = true
+  publicly_accessible        = false
+  storage_encrypted          = false
   auto_minor_version_upgrade = true
-  backup_retention_period = 7
+  backup_retention_period    = 7
 
-  vpc_security_group_ids = [ var.sg_id ]
-  db_subnet_group_name = aws_db_subnet_group.come2us_db_subnet.name
+  vpc_security_group_ids = [var.sg_id]
+  db_subnet_group_name   = aws_db_subnet_group.come2us_db_subnet.name
 
   tags = {
-    Name = "${var.prefix}-primary"
+    Name        = "${var.prefix}-primary"
     Environment = "dev"
-    ManagedBy = "Terraform"
-    Role = "primary"
+    ManagedBy   = "Terraform"
+    Role        = "primary"
   }
 }
 
 resource "aws_db_instance" "come2us_rds_replica" {
-  identifier = "${var.prefix}-replica"
-  replicate_source_db = aws_db_instance.come2us_rds.arn
-  instance_class = var.instance_class
-  publicly_accessible = false
+  identifier                 = "${var.prefix}-replica"
+  replicate_source_db        = aws_db_instance.come2us_rds.arn
+  instance_class             = var.instance_class
+  publicly_accessible        = false
   auto_minor_version_upgrade = true
-  skip_final_snapshot = true
+  skip_final_snapshot        = true
 
-  depends_on = [ aws_db_instance.come2us_rds ]
+  depends_on = [aws_db_instance.come2us_rds]
 
   tags = {
-    Name = "${var.prefix}-replica"
+    Name        = "${var.prefix}-replica"
     Environment = "dev"
-    ManagedBy = "Terraform"
-    Role = "read-replica"
+    ManagedBy   = "Terraform"
+    Role        = "read-replica"
   }
 }

--- a/modules/rds/outputs.tf
+++ b/modules/rds/outputs.tf
@@ -1,13 +1,13 @@
 output "rds_primary" {
-    value = {
-        endpoint = aws_db_instance.come2us_rds.endpoint
-        port = aws_db_instance.come2us_rds.port
-    }
+  value = {
+    endpoint = aws_db_instance.come2us_rds.endpoint
+    port     = aws_db_instance.come2us_rds.port
+  }
 }
 
 output "rds_replica" {
-    value = {
-        endpoint = aws_db_instance.come2us_rds_replica.endpoint
-        port = aws_db_instance.come2us_rds_replica.port
-    }
+  value = {
+    endpoint = aws_db_instance.come2us_rds_replica.endpoint
+    port     = aws_db_instance.come2us_rds_replica.port
+  }
 }

--- a/modules/rds/outputs.tf
+++ b/modules/rds/outputs.tf
@@ -1,0 +1,13 @@
+output "rds_primary" {
+    value = {
+        endpoint = aws_db_instance.come2us_rds.endpoint
+        port = aws_db_instance.come2us_rds.port
+    }
+}
+
+output "rds_replica" {
+    value = {
+        endpoint = aws_db_instance.come2us_rds_replica.endpoint
+        port = aws_db_instance.come2us_rds_replica.port
+    }
+}

--- a/modules/rds/variables.tf
+++ b/modules/rds/variables.tf
@@ -1,0 +1,11 @@
+variable "prefix" {}
+variable "subnet_ids" {}
+variable "vpc_id" {}
+variable "sg_id" {}
+variable "db_name" {}
+variable "username" {}
+variable "password" {}
+variable "instance_class" {}
+variable "port" {}
+variable "engine_version" {}
+variable "allocated_storage" {}

--- a/modules/sg/main.tf
+++ b/modules/sg/main.tf
@@ -96,7 +96,7 @@ resource "aws_security_group" "alb_sg" {
     from_port   = 8080
     to_port     = 8080
     protocol    = "tcp"
-    cidr_blocks = ["10.0.0.0/16"]
+    cidr_blocks = [aws_security_group.backend_sg.id]
   }
 
   tags = {

--- a/modules/sg/main.tf
+++ b/modules/sg/main.tf
@@ -92,14 +92,22 @@ resource "aws_security_group" "alb_sg" {
   }
 
   egress {
-    description = "Allow ALB to reach backend on 8080"
-    from_port   = 8080
-    to_port     = 8080
-    protocol    = "tcp"
-    cidr_blocks = [aws_security_group.backend_sg.id]
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
   }
 
   tags = {
     Name = "come2us-alb-sg"
   }
+}
+
+resource "aws_security_group_rule" "alb_to_backend" {
+  type                     = "egress"
+  from_port                = 8080
+  to_port                  = 8080
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.backend_sg.id
+  security_group_id        = aws_security_group.alb_sg.id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -88,7 +88,13 @@ variable "rds_instance_class" {
 }
 
 variable "rds_allocated_storage" {
+  type = number
   default = 20
+}
+
+variable "rds_engine_version" {
+  type = string
+  default = "17.4"
 }
 
 variable "rds_username" {
@@ -98,6 +104,11 @@ variable "rds_username" {
 variable "rds_password" {
   type      = string
   sensitive = true
+}
+
+variable "rds_port" {
+  type = number
+  default = 5432
 }
 
 # ECR image tag

--- a/variables.tf
+++ b/variables.tf
@@ -57,7 +57,7 @@ variable "private_subnet_cidrs" {
 }
 
 variable "db_subnet_cidrs" {
-  type = list(string)
+  type        = list(string)
   description = "Private subnet CIDRs for RDS"
 }
 
@@ -88,12 +88,12 @@ variable "rds_instance_class" {
 }
 
 variable "rds_allocated_storage" {
-  type = number
+  type    = number
   default = 20
 }
 
 variable "rds_engine_version" {
-  type = string
+  type    = string
   default = "17.4"
 }
 
@@ -107,7 +107,7 @@ variable "rds_password" {
 }
 
 variable "rds_port" {
-  type = number
+  type    = number
   default = 5432
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -56,6 +56,11 @@ variable "private_subnet_cidrs" {
   description = "Private subnet CIDRs"
 }
 
+variable "db_subnet_cidrs" {
+  type = list(string)
+  description = "Private subnet CIDRs for RDS"
+}
+
 variable "enable_nat" {
   type        = bool
   description = "Enable NAT Gateway in public_a"


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #10 

📌 **작업 내용 및 특이사항**
- Terraform 인프라 코드에 RDS(PostgreSQL) 구성 모듈 추가
- Network
  - RDS 전용 DB Subnet 추가
    - `db_private_a`, `db_private_b`
    - 각각 AZ A, B에 위치
    - Public 접근 차단(`publicly_accessible = false`)
- Security Group
  - `rds-sg` 추가
    - Backend SG로부터 PostgreSQL(5432) 접근 허용
    - 외부 접근 차단
- RDS Module
  - 신규 모듈 modules/rds 생성 및 연결
    - Primary(Writer) 인스턴스: Multi-AZ 활성화
    - Read Replica(Reader) 인스턴스
    - 자동 백업(`backup_retention_period = 7`) 및 버전 자동 업그레이드 적용

📚 **참고사항**
- Primary 인스턴스 장애 시 Multi-AZ Standby로 자동 Failover 가 수행됩니다.
- Replica는 비동기 복제(Async) 기반으로 운영되며, 읽기 부하 분산 용도로 사용됩니다.
  - 낙관적 락이 적용되는 **"상품의 재고"**는 read db가 아닌 primary에서 write/read를 모두 수행하는 것이 좋을 것 같습니다.
  - 자세한 내용은 노션에 정리해서 문서화하겠습니다.