### PR TITLE
[Feature] ElastiCache Redis(Session/Cache) 구성 추가

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -95,6 +95,17 @@ module "rds" {
   port              = var.rds_port
 }
 
+module "elasticache" {
+  source         = "./modules/elasticache"
+  prefix         = var.prefix
+  subnet_ids     = module.network.db_subnet_ids
+  sg_id          = module.sg.redis_sg_id
+  azs            = var.azs
+  engine_version = var.elasticache_engine_version
+  node_type      = var.elasticache_node_type
+  auth_token     = var.elasticache_auth_token
+}
+
 resource "aws_ecs_cluster" "come2us" {
   name = "${var.prefix}-cluster"
 }

--- a/modules/elasticache/main.tf
+++ b/modules/elasticache/main.tf
@@ -1,0 +1,67 @@
+resource "aws_elasticache_subnet_group" "come2us_cache_subnet" {
+  name       = "${var.prefix}-cache-subnet-group"
+  subnet_ids = var.subnet_ids
+
+  tags = {
+    Name    = "${var.prefix}-cache-subnet-group"
+    Purpose = "cache"
+  }
+}
+
+
+resource "aws_elasticache_cluster" "come2us_cache_redis" {
+  cluster_id        = "${var.prefix}-cache-redis"
+  engine            = "redis"
+  engine_version    = var.engine_version
+  node_type         = var.node_type
+  num_cache_nodes   = 1
+  port              = 6379
+  availability_zone = var.azs[0]
+
+  parameter_group_name = "default.redis7"
+  subnet_group_name    = aws_elasticache_subnet_group.come2us_cache_subnet.name
+  security_group_ids   = [var.sg_id]
+
+  tags = {
+    Name        = "${var.prefix}-cache"
+    Environment = "dev"
+    ManagedBy   = "Terraform"
+    Purpose     = "cache"
+  }
+}
+
+resource "aws_elasticache_subnet_group" "come2us_session_subnet" {
+  name       = "${var.prefix}-session-subnet-group"
+  subnet_ids = var.subnet_ids
+
+  tags = {
+    Name    = "${var.prefix}-session-subnet-group"
+    Purpose = "session/transient"
+  }
+}
+
+resource "aws_elasticache_replication_group" "come2us_session_redis" {
+  replication_group_id       = "${var.prefix}-session-redis"
+  description                = "Session Redis for transient & session data"
+  engine                     = "redis"
+  engine_version             = var.engine_version
+  node_type                  = var.node_type
+  replicas_per_node_group    = 1
+  port                       = 6380
+  multi_az_enabled           = true
+  automatic_failover_enabled = true
+  at_rest_encryption_enabled = true
+  transit_encryption_enabled = true
+  auth_token                 = var.auth_token
+
+  parameter_group_name = "default.redis7"
+  subnet_group_name    = aws_elasticache_subnet_group.come2us_session_subnet.name
+  security_group_ids   = [var.sg_id]
+
+  tags = {
+    Name        = "${var.prefix}-session-redis"
+    Environment = "dev"
+    ManagedBy   = "Terraform"
+    Purpose     = "session/transient"
+  }
+}

--- a/modules/elasticache/outputs.tf
+++ b/modules/elasticache/outputs.tf
@@ -1,0 +1,14 @@
+output "session_redis" {
+  value = {
+    primary_endpoint = aws_elasticache_replication_group.come2us_session_redis.primary_endpoint_address
+    reader_endpoint  = aws_elasticache_replication_group.come2us_session_redis.reader_endpoint_address
+    port             = aws_elasticache_replication_group.come2us_session_redis.port
+  }
+}
+
+output "cache_redis" {
+  value = {
+    endpoint = aws_elasticache_cluster.come2us_cache_redis.cache_nodes[0].address
+    port     = aws_elasticache_cluster.come2us_cache_redis.cache_nodes[0].port
+  }
+}

--- a/modules/elasticache/variables.tf
+++ b/modules/elasticache/variables.tf
@@ -1,0 +1,7 @@
+variable "prefix" {}
+variable "subnet_ids" {}
+variable "sg_id" {}
+variable "engine_version" {}
+variable "node_type" {}
+variable "auth_token" {}
+variable "azs" {}

--- a/modules/sg/main.tf
+++ b/modules/sg/main.tf
@@ -78,6 +78,30 @@ resource "aws_security_group" "rds_sg" {
   }
 }
 
+resource "aws_security_group" "redis_sg" {
+  name   = "redis-sg"
+  vpc_id = var.vpc_id
+
+  ingress {
+    description     = "Allow Redis access from Backend"
+    from_port       = 6379
+    to_port         = 6380
+    protocol        = "tcp"
+    security_groups = [aws_security_group.backend_sg.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "come2us-redis-sg"
+  }
+}
+
 resource "aws_security_group" "alb_sg" {
   name        = "alb-sg"
   description = "Security group for Application Load Balancer"

--- a/modules/sg/outputs.tf
+++ b/modules/sg/outputs.tf
@@ -2,3 +2,4 @@ output "bastion_sg_id" { value = aws_security_group.bastion_sg.id }
 output "backend_sg_id" { value = aws_security_group.backend_sg.id }
 output "alb_sg_id" { value = aws_security_group.alb_sg.id }
 output "rds_sg_id" { value = aws_security_group.rds_sg.id }
+output "redis_sg_id" { value = aws_security_group.redis_sg.id }

--- a/variables.tf
+++ b/variables.tf
@@ -135,3 +135,20 @@ variable "acm_certificate_arn" {
   description = "ACM Certificate ARN for HTTPS listener"
   type        = string
 }
+
+# ElastiCache
+variable "elasticache_engine_version" {
+  type    = string
+  default = "7.1"
+}
+
+variable "elasticache_node_type" {
+  type    = string
+  default = "cache.t3.micro"
+}
+
+variable "elasticache_auth_token" {
+  type      = string
+  default   = null
+  sensitive = true
+}


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #15 

📌 **작업 내용 및 특이사항**
### Redis(ElastiCache) 이중 구성 추가
- Session Redis
  - Multi-AZ 구성 (`multi_az_enabled = true`)
  - 자동 장애조치(`automatic_failover_enabled = true`)
  - `auth_token` 기반 인증 적용 (Redis 비밀번호)
  - `transit_encryption_enabled = true`, `at_rest_encryption_enabled = true` 설정
    → TLS + KMS 기반 데이터 암호화 적용
  - Port: 6380
  - 목적: 세션 및 트랜지언트 데이터 저장
- Cache Redis
  - 단일 AZ 구성 (비용 최소화)
  - Port: 6379
  - 목적: 캐시 데이터 저장용 (읽기 중심, 고속 접근)
### 네트워크 및 보안 그룹
- Redis 전용 보안 그룹(redis-sg) 추가
  - Backend 서비스에서만 접근 허용
  - 포트 범위: 6379–6380
- RDS와 동일한 DB 전용 서브넷(db-subnet) 에 배치
  → 외부 접근 차단, 내부 통신만 허용

📚 **참고사항**
- `auth_token` 값은 `.tfvars` 또는 CI/CD Secrets로 주입 필요
- Session Redis에 접근하는 클라이언트는 반드시 TLS(rediss://) 기반으로 연결해야 함