### PR TITLE
[Fix] ECS 실행 시 IAM 권한 부족 문제 해결

### DIFF
--- a/bootstrap/policy/terraform_infra_policy.json
+++ b/bootstrap/policy/terraform_infra_policy.json
@@ -68,6 +68,33 @@
         "iam:PassRole"
       ],
       "Resource": "*"
+    },
+    {
+      "Sid": "IamAccessForTerraform",
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateRole",
+        "iam:AttachRolePolicy",
+        "iam:PutRolePolicy",
+        "iam:DeleteRole",
+        "iam:DetachRolePolicy",
+        "iam:GetRole",
+        "iam:ListRolePolicies",
+        "iam:ListAttachedRolePolicies",
+        "iam:ListInstanceProfilesForRole",
+        "iam:PassRole"
+      ],
+      "Resource": "arn:aws:iam::${account_id}:role/*"
+    },
+    {
+      "Sid": "ServiceLinkedRoleAccess",
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateServiceLinkedRole",
+        "iam:GetServiceLinkedRoleDeletionStatus",
+        "iam:DeleteServiceLinkedRole"
+      ],
+      "Resource": "*"
     }
   ]
 }


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #18 

## 📌 **작업 내용 및 특이사항**
- ECS Service 생성 시 IAM 권한 부족(`AccessDenied`) 오류가 발생하던 문제를 해결했습니다.
- Terraform 실행 주체(`terraform-access-role`)에 ECS 및 IAM 관련 리소스를 제어할 수 있는 권한이 누락되어 있었습니다.

### 🔍 원인
- `iam:CreateServiceLinkedRole` 및 IAM Role 제어 관련 권한이 정책에서 빠져 있었음  
- ECS 서비스 생성 시 내부적으로 필요한 **Service Linked Role** 자동 생성 실패로 인해 `InvalidParameterException` 발생

### 🛠️ 변경 사항
`terraform_infra_policy.json` 에 다음 정책 블록을 추가하였습니다.
```json
{
  "Sid": "IamAccessForTerraform",
  "Effect": "Allow",
  "Action": [
    "iam:CreateRole",
    "iam:AttachRolePolicy",
    "iam:PutRolePolicy",
    "iam:DeleteRole",
    "iam:DetachRolePolicy",
    "iam:GetRole",
    "iam:ListRolePolicies",
    "iam:ListAttachedRolePolicies",
    "iam:ListInstanceProfilesForRole",
    "iam:PassRole"
  ],
  "Resource": "arn:aws:iam::${account_id}:role/*"
},
{
  "Sid": "ServiceLinkedRoleAccess",
  "Effect": "Allow",
  "Action": [
    "iam:CreateServiceLinkedRole",
    "iam:GetServiceLinkedRoleDeletionStatus",
    "iam:DeleteServiceLinkedRole"
  ],
  "Resource": "*"
}
```

bootstrap의 다른 리소스(s3+dynamodb 등)를 유지하며 정책에 대한 변경 사항만 적용
```bash
cd bootstrap

terraform apply -target=aws_iam_policy.terraform_infra_policy \
                -target=aws_iam_role_policy_attachment.terraform_role_attach \
                -target=aws_iam_user_policy_attachment.terraform_user_attach
```

### 결과
- Terraform으로 ECS 서비스 및 관련 IAM Role 생성 시 더 이상 `AccessDenied` 발생하지 않음
- ECS Service Linked Role 자동 생성 정상 동작 확인


📚 **참고사항**

